### PR TITLE
Fix action list overflowing on Firefox

### DIFF
--- a/src/utils/createStylingFromTheme.js
+++ b/src/utils/createStylingFromTheme.js
@@ -43,6 +43,7 @@ const getSheetFromColorMap = map => ({
     'flex-direction': 'column',
     width: '100%',
     height: '100%',
+    'max-height': 'calc(100% - 84px)',
     'font-family': 'monaco, Consolas, "Lucida Console", monospace',
     'font-size': '12px',
     'font-smoothing': 'antialiased',

--- a/src/utils/createStylingFromTheme.js
+++ b/src/utils/createStylingFromTheme.js
@@ -43,12 +43,11 @@ const getSheetFromColorMap = map => ({
     'flex-direction': 'column',
     width: '100%',
     height: '100%',
-    'max-height': 'calc(100% - 84px)',
+    overflow: 'auto',
     'font-family': 'monaco, Consolas, "Lucida Console", monospace',
     'font-size': '12px',
     'font-smoothing': 'antialiased',
     'line-height': '1.5em',
-
     'background-color': map.BACKGROUND_COLOR,
     color: map.TEXT_COLOR
   },


### PR DESCRIPTION
This may not be desirable, since it hardcodes the 84px gap needed to ensure that the top and bottom toolbars fit (30 px height + 5 px padding on each side, and 1px border on each side, times 2 toolbars). But it does fix the inspector pane taking up the full height on Firefox. I don't know why it works fine in other browsers without this though...

This is in response to https://github.com/zalmoxisus/redux-devtools-extension/issues/387 , but again, I don't know if this is the right way to fix it.