### PR TITLE
Add overflow:auto to inspector to prevent growing too big in Firefox

### DIFF
--- a/src/utils/createStylingFromTheme.js
+++ b/src/utils/createStylingFromTheme.js
@@ -47,6 +47,7 @@ const getSheetFromColorMap = map => ({
     'font-size': '12px',
     'font-smoothing': 'antialiased',
     'line-height': '1.5em',
+    overflow: 'auto',
 
     'background-color': map.BACKGROUND_COLOR,
     color: map.TEXT_COLOR


### PR DESCRIPTION
This will actually solve a bug in Firefox where Redux Dev Tools seem to grow too big for Firefox's container.

Also mentioned here https://github.com/zalmoxisus/redux-devtools-extension/issues/377